### PR TITLE
feat: add datadog metric output and fix statsd config options

### DIFF
--- a/aplt/metrics.py
+++ b/aplt/metrics.py
@@ -1,0 +1,95 @@
+"""Metrics interface and implementations"""
+from twisted.internet import reactor
+from txstatsd.client import StatsDClientProtocol, TwistedStatsDClient
+from txstatsd.metrics.metrics import Metrics
+
+try:
+    import datadog
+    from datadog import ThreadStats
+    from datadog.util.hostname import get_hostname
+except ImportError:  # pragma: nocover
+    datadog = None
+
+
+class IMetrics(object):
+    """Metrics interface
+    Each method except :meth:`__init__` and :meth:`start` must be implemented.
+    Additional ``kwargs`` may be recorded as additional metric tags for metric
+    systems that support it, otherwise they should be ignored.
+    """
+    def __init__(self, *args, **kwargs):
+        """Setup the metrics"""
+
+    def start(self):
+        """Start any connection needed for metric transmission"""
+
+    def stop(self):
+        """Stop any connection needed"""
+
+    def increment(self, name, count=1, **kwargs):
+        """Increment a counter for a metric name"""
+        raise NotImplementedError("No increment implemented")
+
+    def timing(self, name, duration, **kwargs):
+        """Record a timing in ms for a metric name"""
+        raise NotImplementedError("No timing implemented")
+
+
+class SinkMetrics(IMetrics):
+    """Exists to ignore metrics when metrics are not active"""
+    def increment(self, name, count=1, **kwargs):
+        pass
+
+    def timing(self, name, duration, **kwargs):
+        pass
+
+
+class TwistedMetrics(object):
+    """Twisted implementation of statsd output"""
+    def __init__(self, statsd_host="localhost", statsd_port=8125,
+                 namespace="aplt"):
+        self.client = TwistedStatsDClient(statsd_host, statsd_port)
+        self._metric = Metrics(connection=self.client, namespace=namespace)
+        self._stat_protocol = None
+
+    def start(self):
+        protocol = StatsDClientProtocol(self.client)
+        self._stat_protocol = reactor.listenUDP(0, protocol)
+
+    def stop(self):
+        if self._stat_protocol:  # pragma: nocover
+            self._stat_protocol.stopListening()
+            self._stat_protocol = None
+
+    def increment(self, name, count=1, **kwargs):
+        self._metric.increment(name, count)
+
+    def timing(self, name, duration, **kwargs):
+        self._metric.timing(name, duration)
+
+
+class DatadogMetrics(object):
+    """DataDog Metric backend"""
+    def __init__(self, api_key, app_key, flush_interval=10,
+                 namespace="aplt"):
+
+        datadog.initialize(api_key=api_key, app_key=app_key)
+        self._client = ThreadStats()
+        self._flush_interval = flush_interval
+        self._host = get_hostname()
+        self._namespace = namespace
+
+    def _prefix_name(self, name):
+        return "%s.%s" % (self._namespace, name)
+
+    def start(self):
+        self._client.start(flush_interval=self._flush_interval,
+                           roll_up_interval=self._flush_interval)
+
+    def increment(self, name, count=1, **kwargs):
+        self._client.increment(self._prefix_name(name), count, host=self._host,
+                               **kwargs)
+
+    def timing(self, name, duration, **kwargs):
+        self._client.timing(self._prefix_name(name), value=duration,
+                            host=self._host, **kwargs)

--- a/aplt/tests/test_metrics.py
+++ b/aplt/tests/test_metrics.py
@@ -1,0 +1,64 @@
+import unittest
+
+import twisted.internet.base
+
+from nose.tools import ok_, eq_
+from mock import Mock, patch
+
+from datadog.util.hostname import get_hostname
+
+from aplt.metrics import (
+    IMetrics,
+    DatadogMetrics,
+    TwistedMetrics,
+    SinkMetrics,
+)
+
+
+class IMetricsTestCase(unittest.TestCase):
+    def test_default(self):
+        im = IMetrics()
+        im.start()
+        self.assertRaises(NotImplementedError, im.increment, "test")
+        self.assertRaises(NotImplementedError, im.timing, "test", 10)
+
+
+class SinkMetricsTestCase(unittest.TestCase):
+    def test_passing(self):
+        sm = SinkMetrics()
+        sm.start()
+        eq_(None, sm.increment("test"))
+        eq_(None, sm.timing("test", 10))
+
+
+class TwistedMetricsTestCase(unittest.TestCase):
+    @patch("aplt.metrics.reactor")
+    def test_basic(self, mock_reactor):
+        twisted.internet.base.DelayedCall.debug = True
+        m = TwistedMetrics()
+        m.start()
+        ok_(len(mock_reactor.mock_calls) > 0)
+        m._metric = Mock()
+        m.increment("test", 5)
+        m._metric.increment.assert_called_with("test", 5)
+        m.timing("lifespan", 113)
+        m._metric.timing.assert_called_with("lifespan", 113)
+
+
+class DatadogMetricsTestCase(unittest.TestCase):
+    @patch("aplt.metrics.datadog")
+    def test_basic(self, mock_dog):
+        hostname = get_hostname()
+
+        m = DatadogMetrics("someapikey", "someappkey", namespace="testpush")
+        ok_(len(mock_dog.mock_calls) > 0)
+        m._client = Mock()
+        m.start()
+        m._client.start.assert_called_with(flush_interval=10,
+                                           roll_up_interval=10)
+        m.increment("test", 5)
+        m._client.increment.assert_called_with("testpush.test", 5,
+                                               host=hostname)
+        m.timing("lifespan", 113)
+        m._client.timing.assert_called_with("testpush.lifespan", value=113,
+                                            host=hostname)

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
         "service-identity>=14.0.0",
         "treq>=15.0.0",
         "pyOpenSSL>=0.15.1",
-        "txaio==2.2.0",
+        "txaio==2.2.1",
         "txStatsD==1.0.0",
     ],
     entry_points="""

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ deps =
   coverage
   mock
   codecov
+  datadog
   -rrequirements.txt
 usedevelop = True
 commands =


### PR DESCRIPTION
Add's datadog metrics output option, and fixes an issue with the
command line arguments not getting through to the statsd client.

Closes #25 

@jrconlin r?