### PR TITLE
feat: allow scenarios to restart, and throw exceptions into the scenario

### DIFF
--- a/SCENARIOS.md
+++ b/SCENARIOS.md
@@ -37,6 +37,11 @@ documented in [the SimplePush protocol docs](http://mozilla-push-service.readthe
 
 Any command that lists *arguments* must have all arguments supplied.
 
+Commands *may throw exceptions* if an error occurs. These can occur during any
+of the commands should the connection be dropped unexpectedly, or should a
+notification fail to send. Exceptions will be thrown where the command was
+yielded, and any client connections should be considered invalid.
+
 Full list of commands available in `aplt.commands` module:
 
 * [connect](#connect)
@@ -273,4 +278,24 @@ Generate and return random binary data between the given min/max data length.
 
 ```python
 data = random_data(2048, 4096)
+```
+
+## Decorators
+
+Scenario decorators modify the behavior of a scenario.
+
+Full list of commands available in `aplt.decorators` module:
+
+* [restart](#restart)
+
+### restart
+
+Restart the scenario in the event an uncaught exception occurs. Takes one
+parameter indicating how many times the scenario should be restarted if an
+error occurs, ``0`` may be used to indicate indefinite retries.
+
+```python
+@restart(2)
+def my_scenario():
+    ...
 ```

--- a/aplt/decorators.py
+++ b/aplt/decorators.py
@@ -1,0 +1,10 @@
+"""Scenario decorators"""
+
+
+def restart(tries=3):
+    """Restarts a scenario `times` amount that uncaught exceptions are
+    thrown"""
+    def _restart_decorator(f):
+        f._retries = tries
+        return f
+    return _restart_decorator

--- a/aplt/scenarios.py
+++ b/aplt/scenarios.py
@@ -17,6 +17,7 @@ from aplt.commands import (
     counter,
     wait,
 )
+from aplt.decorators import restart
 
 
 def basic():
@@ -101,3 +102,17 @@ def reconnect_forever(reconnect_delay=300, run_once=0):
         if run_once:
             yield disconnect()
             break
+
+
+##############################################################################
+# TEST SCENARIOS
+##############################################################################
+_RESTARTS = 0
+
+
+@restart(2)
+def _explode():
+    global _RESTARTS
+    yield connect()
+    _RESTARTS += 1
+    yield connect()


### PR DESCRIPTION
Scenarios may now be restarted using the new restart decorator, either a
single time, or indefinitely. To facilitate this, exceptions from command
handling and event handling are now thrown into the generator so they may
be caught by scenario exception handling code, or permitted to escape for
a restart trigger.

Fixes #20 

@jrconlin r?