### PR TITLE
feat: allow a scenario to spin up other scenarios

### DIFF
--- a/SCENARIOS.md
+++ b/SCENARIOS.md
@@ -44,6 +44,7 @@ yielded, and any client connections should be considered invalid.
 
 Full list of commands available in `aplt.commands` module:
 
+* [spawn](#spawn)
 * [connect](#connect)
 * [disconnect](#disconnect)
 * [hello](#hello)
@@ -63,6 +64,19 @@ a `yield`):
 * [random_channel_id](#random_channel_id)
 * [random_data](#random_data)
 
+
+### spawn
+
+Spawns a scenario using a new LoadRunner. The ``test_plan`` should be provided
+in the same format as ``aplt_testplan`` accepts.
+
+**Arguments:** `test_plan`
+
+```python
+yield spawn("aplt.scenarios:reconnect_forever, 1, 1, 0, 200")
+```
+
+**Returns:** ``None``
 
 ### connect
 

--- a/aplt/client.py
+++ b/aplt/client.py
@@ -38,7 +38,7 @@ class WSClientProtocol(WebSocketClientProtocol):
 
 class CommandProcessor(object, policies.TimeoutMixin):
     """Created per Virtual Client to run a client scenario"""
-    valid_commands = ["connect", "disconnect", "register", "hello",
+    valid_commands = ["spawn", "connect", "disconnect", "register", "hello",
                       "unregister", "send_notification", "expect_notification",
                       "ack", "wait", "timer_start", "timer_end", "counter"]
     valid_handlers = ["connect", "disconnect", "error", "hello",
@@ -128,6 +128,11 @@ class CommandProcessor(object, policies.TimeoutMixin):
             command_func(command)
         except:
             self._send_exception()
+
+    def spawn(self, command):
+        """Spawn a new test plan"""
+        self._harness.spawn(command.test_plan)
+        self._send_command_result(None)
 
     def connect(self, command):
         """Run the connect command to start the websocket connection"""

--- a/aplt/commands.py
+++ b/aplt/commands.py
@@ -58,6 +58,10 @@ class counter(namedtuple("Counter", "name count")):
     pass
 
 
+class spawn(namedtuple("Spawn", "test_plan")):
+    pass
+
+
 # Helper functions to use with commands
 def random_channel_id():
     return uuid.uuid4().hex

--- a/aplt/scenarios.py
+++ b/aplt/scenarios.py
@@ -16,6 +16,7 @@ from aplt.commands import (
     timer_end,
     counter,
     wait,
+    spawn,
 )
 from aplt.decorators import restart
 
@@ -116,3 +117,7 @@ def _explode():
     yield connect()
     _RESTARTS += 1
     yield connect()
+
+
+def _test_spawn():
+    yield spawn("aplt.scenarios:basic, 1, 1, 0")


### PR DESCRIPTION
A scenario may now start other scenarios using the test_plan string that
the aplt_testplan script takes using the `spawn` command. The scenario
is not condsidered complete until all running scenarios are finished.

Implementation detail: The runner harness is now spun up under a load runner
in all cases so that additional harnesses may be run for `spawn` commands.

Closes #23 

@jrconlin r?