### PR TITLE
fix: remedy bug with spawning multiple scenarios

### DIFF
--- a/aplt/client.py
+++ b/aplt/client.py
@@ -16,7 +16,10 @@ from twisted.python import log
 
 class WSClientProtocol(WebSocketClientProtocol):
     def onOpen(self):
-        self.processor = self.harness.add_client(self)
+        self.processor = self.factory.harness.add_client(self)
+        if not self.processor:
+            # Unnecessary open, no one waiting
+            return
         self.processor.handle(dict(messageType="connect", client=self))
 
     def onMessage(self, payload, isBinary):
@@ -28,7 +31,7 @@ class WSClientProtocol(WebSocketClientProtocol):
             self.processor.handle(data)
 
     def onClose(self, wasClean, code, reason):
-        self.harness.remove_client(self)
+        self.factory.harness.remove_client(self)
 
         try:
             self.processor.handle(dict(messageType="disconnect",

--- a/aplt/runner.py
+++ b/aplt/runner.py
@@ -44,7 +44,7 @@ class RunnerHarness(object):
             websocket_url,
             headers={"Origin": "localhost:9000"})
         self._factory.protocol = WSClientProtocol
-        self._factory.protocol.harness = self
+        self._factory.harness = self
         if websocket_url.startswith("wss"):
             self._factory_context = ssl.ClientContextFactory()
         else:
@@ -203,9 +203,10 @@ class LoadRunner(object):
         def _run_testplan(self, test_plan):
             scenario, quantity, stagger, overall_delay, scenario_args = \
                 test_plan
-            harness = RunnerHarness(self, self._websocket_url,
-                                    self._statsd_client, scenario,
-                                    *scenario_args[0], **scenario_args[1])
+            harness = RunnerHarness(
+                self, self._websocket_url, self._statsd_client, scenario,
+                *scenario_args[0], **scenario_args[1]
+            )
             self._harnesses.append(harness)
             iterations = quantity / stagger
             for delay in range(iterations):

--- a/aplt/scenarios.py
+++ b/aplt/scenarios.py
@@ -242,6 +242,13 @@ def _test_spawn():
     yield spawn("aplt.scenarios:basic, 1, 1, 0")
 
 
+def _test_multiple_spawn():
+    yield spawn("aplt.scenarios:basic, 1, 1, 0")
+    yield spawn("aplt.scenarios:basic, 1, 1, 0")
+    yield spawn("aplt.scenarios:basic, 1, 1, 0")
+    yield spawn("aplt.scenarios:basic, 1, 1, 0")
+
+
 def _expect_notifications():
     from random import shuffle
     yield connect()

--- a/aplt/tests/__init__.py
+++ b/aplt/tests/__init__.py
@@ -119,6 +119,17 @@ class TestIntegration(unittest.TestCase):
         reactor.callLater(3, self._check_testplan_done, h, d)
         return d
 
+    def test_spawn_multiple_testplan(self):
+        import aplt.runner as runner
+        h = runner.run_scenario({
+            "WEBSOCKET_URL": "wss://autopush-dev.stage.mozaws.net/",
+            "SCENARIO_FUNCTION": "aplt.scenarios:_test_multiple_spawn",
+            "SCENARIO_ARGS": [],
+        }, run=False)
+        d = Deferred()
+        reactor.callLater(3, self._check_testplan_done, h, d)
+        return d
+
     def test_basic_testplan_with_args(self):
         import aplt.runner as runner
         lh = runner.run_testplan({


### PR DESCRIPTION
Previously, the websocket instance was looking for harness off the
protocol instance. Unfortunately the protocol instance is a global
such that the harness kept getting overwritten by each spawned
scenario. The harness is now attached to the factory to avoid having
multiple running scenarios overwrite it.

Closes #49 

@jrconlin r?