### PR TITLE
chore: base the Dockerfile on pypy:2-5.3.1

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -21,6 +21,4 @@ bin/*
 include/*
 lib_pypy/*
 pypy
-pypy2-v5.3.1-linux64
-pypy2-v5.3.1-linux64.tar.bz2
 .coverage

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,6 @@
 # Mozilla AutoPush Load-Tester
 
-# VERSION    0.1
-
-# Extend base debian
-FROM stackbrew/debian:sid
+FROM pypy:2-5.3.1
 
 MAINTAINER Ben Bangert <bbangert@mozilla.com>
 
@@ -13,19 +10,12 @@ ADD . /home/ap-loadtester/
 WORKDIR /home/ap-loadtester
 
 RUN \
-    apt-get update; \
-    apt-get install -y -qq make curl wget bzip2 libexpat1-dev gcc libssl-dev libffi-dev; \
-    apt-get install -y -qq python-virtualenv; \
-    apt-get install -y -qq libexpat1 libssl1.0.0 libffi6; \
-    wget https://bitbucket.org/pypy/pypy/downloads/pypy-5.0.0-linux64.tar.bz2; \
-    tar xjvf pypy-5.0.0-linux64.tar.bz2; \
-    /usr/bin/virtualenv -p pypy-5.0.0-linux64/bin/pypy apenv; \
-    ./apenv/bin/pip install --upgrade pip; \
-    ./apenv/bin/pip install -U setuptools; \
-    ./apenv/bin/pip install pyasn1; \
-    ./apenv/bin/python setup.py develop; \
-    apt-get remove -y -qq make curl wget bzip2 libexpat1-dev gcc libssl-dev libffi-dev; \
-    apt-get autoremove -y -qq; \
+    pip install --upgrade pip && \
+    pip install virtualenv && \
+    virtualenv -p `which pypy` apenv && \
+    ./apenv/bin/pip install pyasn1 && \
+    ./apenv/bin/python setup.py develop && \
+    apt-get autoremove -y -qq && \
     apt-get clean -y
 # End run
 


### PR DESCRIPTION
upgrades back to a more recent version and simplifies it

closes #65