### PR TITLE
bug: invalid arg types not being filtered

### DIFF
--- a/aplt/client.py
+++ b/aplt/client.py
@@ -227,7 +227,7 @@ class CommandProcessor(object, policies.TimeoutMixin):
     def wait(self, command):
         """Wait for a period of time"""
         self._waiting = True
-        self.setTimeout(command.time)
+        self.setTimeout(float(command.time))
 
     def ack(self, command):
         """Acknowledge a message id"""

--- a/aplt/runner.py
+++ b/aplt/runner.py
@@ -367,7 +367,8 @@ def try_int_list_coerce(lst):
         try:
             new_lst.append(int(p))
         except (ValueError, TypeError):
-            new_lst.append(p)
+            # This is not an int. Ignore it.
+            continue
     return new_lst
 
 
@@ -586,6 +587,9 @@ def run_scenario(args=None, run=True):
     scenario_kw = {}
     if arguments.scenario_args:
         scenario_args, scenario_kw = group_kw_args(arguments.scenario_args)
+        # override the --websocket_url if the older argument form is used.
+        if str(scenario_args[0]).startswith('ws'):
+            arguments.websocket_url = scenario_args.pop()
         scenario_args = try_int_list_coerce(scenario_args)
         verify_arguments(scenario, *scenario_args, **scenario_kw)
     endpoint, ssl_cert, ssl_key = parse_endpoint_args(arguments)

--- a/aplt/tests/__init__.py
+++ b/aplt/tests/__init__.py
@@ -221,9 +221,9 @@ class TestIntegration(unittest.TestCase):
     def test_expect_notifications(self):
         import aplt.runner as runner
         h = runner.run_scenario([
-            "--log_output=none",
-            "--websocket_url={}".format(AUTOPUSH_SERVER),
             "aplt.scenarios:_expect_notifications",
+            AUTOPUSH_SERVER,
+            "--log_output=none",
         ], run=False)
         d = Deferred()
         reactor.callLater(0, self._check_testplan_done, h, d)
@@ -284,7 +284,7 @@ class TestRunnerFunctions(unittest.TestCase):
     def test_verify_func_too_many_args(self):
         from aplt.runner import verify_arguments
         from aplt.scenarios import connect_and_idle_forever
-        verify_arguments(connect_and_idle_forever, "extra_arg")
+        verify_arguments(connect_and_idle_forever, 0, 0, "extra_arg")
 
     @raises(Exception)
     def test_verify_func_short_an_arg(self):


### PR DESCRIPTION
The original bug noted that some scenarios failed because of a bad
argument or too many args being passed. This was actually due to
non-numeric values leaking into the call arguments.

Closes #103#