### PR TITLE
 feat: Add support for calling from pytest 

### DIFF
--- a/aplt/runner.py
+++ b/aplt/runner.py
@@ -611,6 +611,7 @@ def run_scenario(args=None, run=True):
     log.startLoggingWithObserver(observer.emit, False)
     logging.basicConfig(level=val_to_level(arguments.log_level))
     statsd_client.start()
+    lh.logging = observer
     lh.metrics = statsd_client
     lh.start()
 

--- a/aplt/tests/__init__.py
+++ b/aplt/tests/__init__.py
@@ -46,14 +46,35 @@ class TestIntegration(unittest.TestCase):
             return pool.closeCachedConnections()
 
     def test_basic_runner(self):
+        """Test the "basic" scenario.
+
+        This can be called via pytest using
+        `bin/pytest aplt/tests/__init__.py::TestIntegration::test_basic_runner`
+
+        Use `check_log` to examine the produced log file for whatever values
+        you need.
+
+        """  # pragma noqa
         import aplt.runner as runner
         h = runner.run_scenario([
-            "--log_output=none",
+            "--log_format=json",
+            "--log_output=buffer",  # send the output to a string buffer
             "--websocket_url={}".format(AUTOPUSH_SERVER),
             "aplt.scenarios:basic",
         ], run=False)
+
+        def check_log(success):
+            """Check the captured output log for whatever content your
+            looking for
+
+            """
+            dump = h.logging.dump()
+            assert len(dump) > 0
+            # Additional checks here...
+
         d = Deferred()
         reactor.callLater(0, self._check_testplan_done, h, d)
+        d.addCallback(check_log)
         return d
 
     def test_basic_with_vapid(self):

--- a/aplt/tests/test_logging.py
+++ b/aplt/tests/test_logging.py
@@ -59,14 +59,14 @@ class TestLogger(unittest.TestCase):
                      time=time.time(),
                      log_text='Log opened.',
                      log_format=u'{log_text}',
-                     message=('Log opened.',),
+                     message='Log opened.',
                      isError=0,
                      reason='some reason',
                      )
         obj.emit(event)
         buff.seek(0)
         out = json.loads(buff.read())
-        eq_(out['log_level'], event['log_level'])
+        eq_(out['log_level'], event['log_level'].name)
         eq_(out['message'], event['message'])
         eq_(out['isError'], event['isError'])
         eq_(out['reason'], event['reason'])

--- a/aplt/tests/test_vapid.py
+++ b/aplt/tests/test_vapid.py
@@ -34,7 +34,7 @@ T_PUBLIC_RAW = """EJwJZq_GN8jJbo1GGpyU70hmP2hbWAUpQFKDBy\
 KB81yldJ9GTklBM5xqEwuPM7VuQcyiLDhvovthPIXx-gsQRQ=="""
 
 
-def setUp(self):
+def setup_module(self):
     ff = open('/tmp/private', 'w')
     ff.write(T_PRIVATE_PEM)
     ff.close()
@@ -43,7 +43,7 @@ def setUp(self):
     ff.close()
 
 
-def tearDown(self):
+def teardown_module(self):
     os.unlink('/tmp/private')
     os.unlink('/tmp/public')
 


### PR DESCRIPTION
Pytest introduces a few interesting complications, however it's possible
to call an individual test. e.g.
`bin/pytest aplt/tests/__init__.py::TestIntegration::test_basic_runner`

There may be some additional pytest specific optimizations that we
could include, but incremental improvements may be the best path
forward.

Closes #105